### PR TITLE
return error text and add validateCartBadge helper

### DIFF
--- a/pages/inventoryPage.js
+++ b/pages/inventoryPage.js
@@ -80,6 +80,13 @@ export class InventoryPage {
 		return text;
 	}
 
+	async validateCartBadge(expectedCount) {
+		const current = await this.getCartBadge();
+		if (current !== expectedCount) {
+			throw new Error(`Cart badge mismatch: expected "${expectedCount}" but got "${current}"`);
+		}
+	}
+
 	async getProductsListItemsName() {
 		return await this.productsListItemsName.allTextContents();
 	}

--- a/pages/loginPage.js
+++ b/pages/loginPage.js
@@ -20,6 +20,6 @@ export class LoginPage {
     }
 
     async getErrorMessage() {
-        await this.errorMessage.innerText();
+		return await this.errorMessage.innerText();
     }
 }


### PR DESCRIPTION
Make LoginPage.getErrorMessage() return the error text.
Add InventoryPage.validateCartBadge(expectedCount) and use getCartBadge() internally.
Improves reliability and aligns with existing tests.